### PR TITLE
Bump to 1.4.8 and include configmap possibility

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.3.6"
+appVersion: "1.4.4"
 description: A Helm chart for Kubernetes
 name: roundcube
-version: 0.1.1
+version: 0.2.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.4.4"
+appVersion: "1.4.8"
 description: A Helm chart for Kubernetes
 name: roundcube
-version: 0.2.1
+version: 0.2.2
 icon: https://github.com/roundcube/roundcubemail/blob/master/skins/classic/images/roundcube_logo.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 appVersion: "1.4.4"
 description: A Helm chart for Kubernetes
 name: roundcube
-version: 0.2.0
+version: 0.2.1
+icon: https://github.com/roundcube/roundcubemail/blob/master/skins/classic/images/roundcube_logo.png

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.configs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "roundcube.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "roundcube.name" . }}
+    helm.sh/chart: {{ include "roundcube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.configs }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "roundcube.fullname" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,9 +45,10 @@ spec:
           volumeMounts:
           - mountPath: /usr/local/share/ca-certificates
             name: ca
-# TODO
-#          - mountPath: /var/roundcube/config
-#            name: data
+{{- if .Values.configs -}}
+          - mountPath: /var/roundcube/config
+            name: config
+{{- end }}
       volumes:
       - name: ca
         {{- if .Values.ca }}
@@ -62,6 +63,10 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+{{- if .Values.configs -}}
+      - name: config
+        configMap: {{ template "roundcube.fullname" . }}-config
+{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -72,3 +72,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+configs: {}

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: roundcube/roundcubemail
-  tag: 1.4.4-apache
+  tag: 1.4.8-apache
   pullPolicy: IfNotPresent
 
 args: [ sh, -c, 'update-ca-certificates && /docker-entrypoint.sh apache2-foreground' ]

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: roundcube/roundcubemail
-  tag: 1.3.6
+  tag: 1.4.4-apache
   pullPolicy: IfNotPresent
 
 args: [ sh, -c, 'update-ca-certificates && /docker-entrypoint.sh apache2-foreground' ]


### PR DESCRIPTION
This PR:
- updates the app version to 1.4.8 and 
- includes a possibility for a configmap, to contain additional config. to be mounted on /var/roundcube/config (advanced configuration of the docker image). This is done by setting the "configs" Value to a key/value.

Example
```yaml
configs:
    myconf.cfg: $config[roundcube_config_option] = true;
```
